### PR TITLE
Add repo-setup Agent Skill with skill discovery and vetting guidance

### DIFF
--- a/.github/skills/repo-setup/SKILL.md
+++ b/.github/skills/repo-setup/SKILL.md
@@ -22,14 +22,11 @@ Do this first — declaring what the repo is drives the license, Azure, and skil
 - **Update AGENTS.md.** Trim or rewrite [AGENTS.md](../../../AGENTS.md) to reflect this repository's actual purpose and conventions.
 - **Consider the license.** The template omits one intentionally. Discuss the appropriate license and add a `LICENSE` file once the user has chosen one; do not pick one for them.
 
-## Equip agents with relevant skills
-
-Do this early, right after identity is declared: installing skills that match the stack makes the agent more capable for the remaining setup. Not a one-time step either — worth repeating over time as new skills appear. See [Discover and install Agent Skills](#discover-and-install-agent-skills) below.
-
 ## Configure for the declared stack
 
 Independent steps — apply those that fit, in any order.
 
+- **Equip agents with relevant skills.** Not a one-time step — most valuable now that the stack is declared, and worth repeating over time as new skills appear. See [Discover and install Agent Skills](#discover-and-install-agent-skills) below.
 - **Decide whether the repo uses Azure.** If it does not, raise removing the Azure-oriented scaffolding — the OIDC, E2E, and azd workflows under `.github/workflows/` and the `docs/azure-*.md` guides — so the repository stays lean and technology-neutral; confirm with the user before deleting anything. If it does, continue with the next two items.
 - **Configure Azure OIDC** (Azure only). Set up federated credentials and the `AZURE_CLIENT_ID` variable plus `AZURE_TENANT_ID` / `AZURE_SUBSCRIPTION_ID` secrets, following [docs/azure-oidc-setup.md](../../../docs/azure-oidc-setup.md). Then have the user run the **Azure OIDC Connectivity Check** workflow to verify.
 - **Enable AI agent Azure access** (Azure only). Run `azd coding-agent config` to give agents read-time visibility into Azure state. See [docs/azure-coding-agent-guide.md](../../../docs/azure-coding-agent-guide.md).

--- a/.github/skills/repo-setup/SKILL.md
+++ b/.github/skills/repo-setup/SKILL.md
@@ -22,6 +22,10 @@ Do this first — declaring what the repo is drives the license, Azure, and skil
 - **Update AGENTS.md.** Trim or rewrite [AGENTS.md](../../../AGENTS.md) to reflect this repository's actual purpose and conventions.
 - **Consider the license.** The template omits one intentionally. Discuss the appropriate license and add a `LICENSE` file once the user has chosen one; do not pick one for them.
 
+## Equip agents with relevant skills
+
+Do this early, right after identity is declared: installing skills that match the stack makes the agent more capable for the remaining setup. Not a one-time step either — worth repeating over time as new skills appear. See [Discover and install Agent Skills](#discover-and-install-agent-skills) below.
+
 ## Configure for the declared stack
 
 Independent steps — apply those that fit, in any order.
@@ -29,7 +33,6 @@ Independent steps — apply those that fit, in any order.
 - **Decide whether the repo uses Azure.** If it does not, raise removing the Azure-oriented scaffolding — the OIDC, E2E, and azd workflows under `.github/workflows/` and the `docs/azure-*.md` guides — so the repository stays lean and technology-neutral; confirm with the user before deleting anything. If it does, continue with the next two items.
 - **Configure Azure OIDC** (Azure only). Set up federated credentials and the `AZURE_CLIENT_ID` variable plus `AZURE_TENANT_ID` / `AZURE_SUBSCRIPTION_ID` secrets, following [docs/azure-oidc-setup.md](../../../docs/azure-oidc-setup.md). Then have the user run the **Azure OIDC Connectivity Check** workflow to verify.
 - **Enable AI agent Azure access** (Azure only). Run `azd coding-agent config` to give agents read-time visibility into Azure state. See [docs/azure-coding-agent-guide.md](../../../docs/azure-coding-agent-guide.md).
-- **Equip agents with relevant skills.** Not a one-time step — most valuable now that the stack is declared, and worth repeating over time as new skills appear. See [Discover and install Agent Skills](#discover-and-install-agent-skills) below.
 
 ## Wind down the template scaffolding
 

--- a/.github/skills/repo-setup/SKILL.md
+++ b/.github/skills/repo-setup/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: repo-setup
+description: Use when setting up or initializing a repository created from the repo-baseline template (prompts like "set up this repo", "finish the post-creation checklist", or "what should I configure now?"). Guides choosing a license, configuring Azure OIDC, enabling AI agent Azure access, discovering and installing Agent Skills relevant to the repository's technology stack, and replacing the template documentation. Do not use for general feature work in an already-configured repository.
+---
+
+# Repo Setup
+
+Guide a contributor (or yourself) through configuring a repository that was created from the **repo-baseline** template.
+
+Work through the steps in order. Treat any authentication, GUI, or portal step as **blocking**: stop and hand back to the user, then continue once they confirm. Keep every change lean and public-safe — never add secrets, tenant/subscription IDs, a license, or technology-specific scaffolding the user has not asked for. See [CONTRIBUTING.md](../../../CONTRIBUTING.md) for the canonical constraints.
+
+## First, determine the context
+
+Before doing anything, work out whether you are in **repo-baseline itself** or in a **repository derived from it**. Signals that you are still in the template: the repository or remote is named `repo-baseline`, the `README.md` is still titled `# repo-baseline`, or `AGENTS.md` still describes "a baseline template repository."
+
+- **If this is the template itself:** do not perform setup — there is nothing here to configure. You are most likely maintaining or testing this skill; act on that intent instead.
+- **If this is a derived repository:** proceed with the steps below.
+
+## Setup steps
+
+1. **Choose a license.** The template omits one intentionally. Add a `LICENSE` file only when the user has chosen a license; do not pick one for them.
+2. **Configure Azure OIDC** (only if the repo uses Azure). Set up federated credentials and the `AZURE_CLIENT_ID` variable plus `AZURE_TENANT_ID` / `AZURE_SUBSCRIPTION_ID` secrets, following [docs/azure-oidc-setup.md](../../../docs/azure-oidc-setup.md). Then have the user run the **Azure OIDC Connectivity Check** workflow to verify.
+3. **Enable AI agent Azure access** (only if using Azure with the Copilot coding agent). Run `azd coding-agent config` to give agents read-time visibility into Azure state. See [docs/azure-coding-agent-guide.md](../../../docs/azure-coding-agent-guide.md).
+4. **Decide on the optional Azure scaffolding.** The template ships Azure-oriented assets — the OIDC, E2E, and azd workflows under `.github/workflows/` and the `docs/azure-*.md` guides. These are optional defaults, not requirements. If the project is not using Azure, raise removing them so the repository stays lean and technology-neutral; confirm with the user before deleting anything.
+5. **Discover and install relevant Agent Skills.** See [Discover and install Agent Skills](#discover-and-install-agent-skills) below.
+6. **Replace the template README.** Swap the generic `README.md` for documentation specific to this repository.
+7. **Review AGENTS.md.** Update or trim [AGENTS.md](../../../AGENTS.md) to reflect this repository's actual purpose and conventions.
+8. **Retire this skill.** In the same spirit as replacing the README and updating AGENTS.md, this `repo-setup` skill is itself bootstrap scaffolding. Once setup is complete, offer to remove it (the `.github/skills/repo-setup/` directory) and the Post-Creation Checklist from the README; it exists to start a repository, not to live in it.
+
+## Discover and install Agent Skills
+
+Agent Skills are reusable, tool-portable capabilities defined by the [SKILL.md open standard](https://agentskills.io). Install skills that match **this** repository's technology stack and goals — skip anything irrelevant, since unused skills are noise.
+
+### Where to look (in priority order)
+
+1. **The vendor that owns the technology.** First-party skills are the highest-trust option. Look for official skills published by the maintainers of the language, framework, or platform the repo uses — search `github.com/<vendor>/skills` or the vendor's documentation.
+2. **GitHub Copilot's default marketplaces** (pre-registered, no setup): [`github/copilot-plugins`](https://github.com/github/copilot-plugins) (official, GitHub-maintained) and [`github/awesome-copilot`](https://github.com/github/awesome-copilot) (large, community-contributed). See the official guidance on [agent skills](https://docs.github.com/en/copilot/concepts/agents/about-agent-skills) and [plugins](https://docs.github.com/en/copilot/concepts/agents/about-plugins).
+3. **Search across GitHub:** `gh skill search <keyword>` finds `SKILL.md` skills in public repositories (GitHub CLI v2.90.0+).
+
+### Install (GitHub Copilot)
+
+```bash
+gh skill preview <owner/repo> <skill>   # always inspect first
+gh skill install <owner/repo> <skill>   # installs into .github/skills/
+```
+
+- Commit installed skills under `.github/skills/` when they should apply to everyone working in the repository.
+- Pin a version for stability: `gh skill install <owner/repo> <skill>@<version>`.
+
+### Notes
+
+- **Skills are not verified or signed.** Always inspect a skill's contents (especially any `scripts/`) before installing — they can contain prompt injection or executable code.
+- **Installers are interchangeable.** The same skill can be installed with `gh skill install`, with `npx skills add <owner/repo>`, or by placing the skill folder directly in `.github/skills/` (or `.agents/skills/` for cross-tool use). Choose whichever matches the agent in use.

--- a/.github/skills/repo-setup/SKILL.md
+++ b/.github/skills/repo-setup/SKILL.md
@@ -33,7 +33,7 @@ Agent Skills are reusable, tool-portable capabilities defined by the [SKILL.md o
 
 ### Where to look (in priority order)
 
-1. **The vendor that owns the technology.** First-party skills are the highest-trust option. Look for official skills published by the maintainers of the language, framework, or platform the repo uses — search `github.com/<vendor>/skills` or the vendor's documentation.
+1. **The vendor that owns the technology.** First-party skills are the highest-trust option. Look for official skills published by the maintainers of the language, framework, or platform the repo uses — search `github.com/<vendor>/skills` or the vendor's documentation. Also consider your own or your organization's curated skills repository (e.g. [`rukasakurai/agent-skills`](https://github.com/rukasakurai/agent-skills)).
 2. **GitHub Copilot's default marketplaces** (pre-registered, no setup): [`github/copilot-plugins`](https://github.com/github/copilot-plugins) (official, GitHub-maintained) and [`github/awesome-copilot`](https://github.com/github/awesome-copilot) (large, community-contributed). See the official guidance on [agent skills](https://docs.github.com/en/copilot/concepts/agents/about-agent-skills) and [plugins](https://docs.github.com/en/copilot/concepts/agents/about-plugins).
 3. **Search across GitHub:** `gh skill search <keyword>` finds `SKILL.md` skills in public repositories (GitHub CLI v2.90.0+).
 

--- a/.github/skills/repo-setup/SKILL.md
+++ b/.github/skills/repo-setup/SKILL.md
@@ -5,25 +5,35 @@ description: Use when setting up, initializing, or revisiting a repository creat
 
 # Repo Setup
 
-Work through the steps in order. Treat any authentication, GUI, or portal step as **blocking**: stop and hand back to the user, then continue once they confirm. Keep every change lean and public-safe — never add secrets, tenant/subscription IDs, a license, or technology-specific scaffolding the user has not asked for. See [CONTRIBUTING.md](../../../CONTRIBUTING.md) for the canonical constraints.
+Most steps below are independent — do the ones that apply, in any order. Two real constraints: settle whether the repo uses Azure before configuring Azure, and finalize (the **Wind down the template scaffolding** group) only once the rest is done. Treat any authentication, GUI, or portal step as **blocking**: stop and hand back to the user, then continue once they confirm. Keep every change lean and public-safe — never add secrets, tenant/subscription IDs, a license, or technology-specific scaffolding the user has not asked for. See [CONTRIBUTING.md](../../../CONTRIBUTING.md) for the canonical constraints.
 
 ## First, determine the context
 
 Before doing anything, work out whether you are in **repo-baseline itself** or in a **repository derived from it**. Signals that you are still in the template: the repository or remote is named `repo-baseline`, the `README.md` is still titled `# repo-baseline`, or `AGENTS.md` still describes "a baseline template repository."
 
 - **If this is the template itself:** do not perform setup — there is nothing here to configure. You are most likely maintaining or testing this skill; act on that intent instead.
-- **If this is a derived repository:** proceed with the steps below.
+- **If this is a derived repository:** proceed below.
 
-## Setup steps
+## Bootstrap configuration
 
-1. **Choose a license.** The template omits one intentionally. Add a `LICENSE` file only when the user has chosen a license; do not pick one for them.
-2. **Configure Azure OIDC** (only if the repo uses Azure). Set up federated credentials and the `AZURE_CLIENT_ID` variable plus `AZURE_TENANT_ID` / `AZURE_SUBSCRIPTION_ID` secrets, following [docs/azure-oidc-setup.md](../../../docs/azure-oidc-setup.md). Then have the user run the **Azure OIDC Connectivity Check** workflow to verify.
-3. **Enable AI agent Azure access** (only if using Azure with the Copilot coding agent). Run `azd coding-agent config` to give agents read-time visibility into Azure state. See [docs/azure-coding-agent-guide.md](../../../docs/azure-coding-agent-guide.md).
-4. **Decide on the optional Azure scaffolding.** The template ships Azure-oriented assets — the OIDC, E2E, and azd workflows under `.github/workflows/` and the `docs/azure-*.md` guides. These are optional defaults, not requirements. If the project is not using Azure, raise removing them so the repository stays lean and technology-neutral; confirm with the user before deleting anything.
-5. **Discover and install relevant Agent Skills.** See [Discover and install Agent Skills](#discover-and-install-agent-skills) below.
-6. **Replace the template README.** Swap the generic `README.md` for documentation specific to this repository.
-7. **Review AGENTS.md.** Update or trim [AGENTS.md](../../../AGENTS.md) to reflect this repository's actual purpose and conventions.
-8. **Retire this skill.** In the same spirit as replacing the README and updating AGENTS.md, this `repo-setup` skill is itself bootstrap scaffolding. Once setup is complete, offer to remove it (the `.github/skills/repo-setup/` directory) and the Post-Creation Checklist from the README; it exists to start a repository, not to live in it.
+One-time choices for a new repository. Apply those that fit.
+
+- **Choose a license.** The template omits one intentionally. Add a `LICENSE` file only when the user has chosen a license; do not pick one for them.
+- **Decide whether the repo uses Azure.** If it does not, raise removing the Azure-oriented scaffolding — the OIDC, E2E, and azd workflows under `.github/workflows/` and the `docs/azure-*.md` guides — so the repository stays lean and technology-neutral; confirm with the user before deleting anything. If it does, continue with the next two items.
+- **Configure Azure OIDC** (Azure only). Set up federated credentials and the `AZURE_CLIENT_ID` variable plus `AZURE_TENANT_ID` / `AZURE_SUBSCRIPTION_ID` secrets, following [docs/azure-oidc-setup.md](../../../docs/azure-oidc-setup.md). Then have the user run the **Azure OIDC Connectivity Check** workflow to verify.
+- **Enable AI agent Azure access** (Azure only). Run `azd coding-agent config` to give agents read-time visibility into Azure state. See [docs/azure-coding-agent-guide.md](../../../docs/azure-coding-agent-guide.md).
+
+## Equip agents with relevant skills
+
+Not a one-time step — most valuable once the repository has a real technology stack, and worth repeating over time as new skills appear. See [Discover and install Agent Skills](#discover-and-install-agent-skills) below.
+
+## Wind down the template scaffolding
+
+Do these last: each removes part of what this skill relies on — its entry point, its detection signals, or the skill itself.
+
+- **Replace the template README.** Swap the generic `README.md` (including its Post-Creation Checklist) for documentation specific to this repository.
+- **Review AGENTS.md.** Update or trim [AGENTS.md](../../../AGENTS.md) to reflect this repository's actual purpose and conventions.
+- **Retire this skill.** This `repo-setup` skill is itself bootstrap scaffolding. Once setup is complete, offer to remove it (the `.github/skills/repo-setup/` directory); it exists to start a repository, not to live in it. Keep it only if the user wants to revisit skill discovery periodically.
 
 ## Discover and install Agent Skills
 

--- a/.github/skills/repo-setup/SKILL.md
+++ b/.github/skills/repo-setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: repo-setup
-description: Use when setting up or initializing a repository created from the repo-baseline template (prompts like "set up this repo", "finish the post-creation checklist", or "what should I configure now?"). Guides choosing a license, configuring Azure OIDC, enabling AI agent Azure access, discovering and installing Agent Skills relevant to the repository's technology stack, and replacing the template documentation.
+description: Use when setting up, initializing, or revisiting a repository created from the repo-baseline template — e.g. "set up this repo", "finish the post-creation checklist", "what should I configure now?", or when the user wants to add a license, wire up Azure OIDC, find and install Agent Skills relevant to the repo, or replace the template's starter documentation.
 ---
 
 # Repo Setup

--- a/.github/skills/repo-setup/SKILL.md
+++ b/.github/skills/repo-setup/SKILL.md
@@ -5,7 +5,7 @@ description: Use when setting up, initializing, or revisiting a repository creat
 
 # Repo Setup
 
-Most steps below are independent — do the ones that apply, in any order. Two real constraints: settle whether the repo uses Azure before configuring Azure, and finalize (the **Wind down the template scaffolding** group) only once the rest is done. Treat any authentication, GUI, or portal step as **blocking**: stop and hand back to the user, then continue once they confirm. Keep every change lean and public-safe — never add secrets, tenant/subscription IDs, a license, or technology-specific scaffolding the user has not asked for. See [CONTRIBUTING.md](../../../CONTRIBUTING.md) for the canonical constraints.
+Establish the repository's identity first; the rest depends on it. Most remaining steps are independent — do the ones that apply, in any order. A few real constraints: settle whether the repo uses Azure before configuring Azure, and wind down the scaffolding only once the rest is done. Treat any authentication, GUI, or portal step as **blocking**: stop and hand back to the user, then continue once they confirm. Keep every change lean and public-safe — never add secrets, tenant/subscription IDs, a license, or technology-specific scaffolding the user has not asked for. See [CONTRIBUTING.md](../../../CONTRIBUTING.md) for the canonical constraints.
 
 ## First, determine the context
 
@@ -14,25 +14,28 @@ Before doing anything, work out whether you are in **repo-baseline itself** or i
 - **If this is the template itself:** do not perform setup — there is nothing here to configure. You are most likely maintaining or testing this skill; act on that intent instead.
 - **If this is a derived repository:** proceed below.
 
-## Bootstrap configuration
+## Establish the repository's identity
 
-One-time choices for a new repository. Apply those that fit.
+Do this first — declaring what the repo is drives the license, Azure, and skill decisions that follow, and makes AGENTS.md authoritative for the rest of the work.
 
-- **Choose a license.** The template omits one intentionally. Add a `LICENSE` file only when the user has chosen a license; do not pick one for them.
+- **Rewrite the README's descriptive content.** Replace the template's title and "what this is" framing with this repository's real purpose, stack, and usage. (Leave the Post-Creation Checklist for now — it is removed during wind-down.)
+- **Update AGENTS.md.** Trim or rewrite [AGENTS.md](../../../AGENTS.md) to reflect this repository's actual purpose and conventions.
+- **Consider the license.** The template omits one intentionally. Discuss the appropriate license and add a `LICENSE` file once the user has chosen one; do not pick one for them.
+
+## Configure for the declared stack
+
+Independent steps — apply those that fit, in any order.
+
 - **Decide whether the repo uses Azure.** If it does not, raise removing the Azure-oriented scaffolding — the OIDC, E2E, and azd workflows under `.github/workflows/` and the `docs/azure-*.md` guides — so the repository stays lean and technology-neutral; confirm with the user before deleting anything. If it does, continue with the next two items.
 - **Configure Azure OIDC** (Azure only). Set up federated credentials and the `AZURE_CLIENT_ID` variable plus `AZURE_TENANT_ID` / `AZURE_SUBSCRIPTION_ID` secrets, following [docs/azure-oidc-setup.md](../../../docs/azure-oidc-setup.md). Then have the user run the **Azure OIDC Connectivity Check** workflow to verify.
 - **Enable AI agent Azure access** (Azure only). Run `azd coding-agent config` to give agents read-time visibility into Azure state. See [docs/azure-coding-agent-guide.md](../../../docs/azure-coding-agent-guide.md).
-
-## Equip agents with relevant skills
-
-Not a one-time step — most valuable once the repository has a real technology stack, and worth repeating over time as new skills appear. See [Discover and install Agent Skills](#discover-and-install-agent-skills) below.
+- **Equip agents with relevant skills.** Not a one-time step — most valuable now that the stack is declared, and worth repeating over time as new skills appear. See [Discover and install Agent Skills](#discover-and-install-agent-skills) below.
 
 ## Wind down the template scaffolding
 
-Do these last: each removes part of what this skill relies on — its entry point, its detection signals, or the skill itself.
+Do this last: it removes the skill's own entry point and the skill itself.
 
-- **Replace the template README.** Swap the generic `README.md` (including its Post-Creation Checklist) for documentation specific to this repository.
-- **Review AGENTS.md.** Update or trim [AGENTS.md](../../../AGENTS.md) to reflect this repository's actual purpose and conventions.
+- **Remove the Post-Creation Checklist** from the README — the leftover template breadcrumb that points at this skill.
 - **Retire this skill.** This `repo-setup` skill is itself bootstrap scaffolding. Once setup is complete, offer to remove it (the `.github/skills/repo-setup/` directory); it exists to start a repository, not to live in it. Keep it only if the user wants to revisit skill discovery periodically.
 
 ## Discover and install Agent Skills

--- a/.github/skills/repo-setup/SKILL.md
+++ b/.github/skills/repo-setup/SKILL.md
@@ -45,9 +45,13 @@ gh skill install <owner/repo> <skill>   # installs into .github/skills/
 ```
 
 - Commit installed skills under `.github/skills/` when they should apply to everyone working in the repository.
-- Pin a version for stability: `gh skill install <owner/repo> <skill>@<version>`.
+- Pin to a reviewed version or commit SHA so later updates can't silently swap in changed content: `gh skill install <owner/repo> <skill>@<version>` (or `--pin`). `gh skill install` records the source repo, ref, and tree SHA in the skill's frontmatter as provenance.
 
-### Notes
+### Security notes
 
-- **Skills are not verified or signed.** Always inspect a skill's contents (especially any `scripts/`) before installing — they can contain prompt injection or executable code.
+Treat a third-party skill as untrusted supply-chain content: its instructions enter the agent's context and its bundled scripts may be executed.
+
+- **Skills are not verified or signed.** Inspect before installing — not just any `scripts/`, but the instruction body too, which can carry hidden or obfuscated prompt-injection directives (e.g. to exfiltrate secrets or run commands).
+- **Do not pre-approve `shell`/`bash`** in a skill's `allowed-tools` unless you have reviewed the skill and its scripts and trust the source — doing so lets a malicious or injected skill run arbitrary commands without confirmation.
+- **Prefer trusted, first-party sources** and the least privilege the task needs.
 - **Installers are interchangeable.** The same skill can be installed with `gh skill install`, with `npx skills add <owner/repo>`, or by placing the skill folder directly in `.github/skills/` (or `.agents/skills/` for cross-tool use). Choose whichever matches the agent in use.

--- a/.github/skills/repo-setup/SKILL.md
+++ b/.github/skills/repo-setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: repo-setup
-description: Use when setting up or initializing a repository created from the repo-baseline template (prompts like "set up this repo", "finish the post-creation checklist", or "what should I configure now?"). Guides choosing a license, configuring Azure OIDC, enabling AI agent Azure access, discovering and installing Agent Skills relevant to the repository's technology stack, and replacing the template documentation. Do not use for general feature work in an already-configured repository.
+description: Use when setting up or initializing a repository created from the repo-baseline template (prompts like "set up this repo", "finish the post-creation checklist", or "what should I configure now?"). Guides choosing a license, configuring Azure OIDC, enabling AI agent Azure access, discovering and installing Agent Skills relevant to the repository's technology stack, and replacing the template documentation.
 ---
 
 # Repo Setup

--- a/.github/skills/repo-setup/SKILL.md
+++ b/.github/skills/repo-setup/SKILL.md
@@ -5,8 +5,6 @@ description: Use when setting up or initializing a repository created from the r
 
 # Repo Setup
 
-Guide a contributor (or yourself) through configuring a repository that was created from the **repo-baseline** template.
-
 Work through the steps in order. Treat any authentication, GUI, or portal step as **blocking**: stop and hand back to the user, then continue once they confirm. Keep every change lean and public-safe — never add secrets, tenant/subscription IDs, a license, or technology-specific scaffolding the user has not asked for. See [CONTRIBUTING.md](../../../CONTRIBUTING.md) for the canonical constraints.
 
 ## First, determine the context
@@ -29,7 +27,7 @@ Before doing anything, work out whether you are in **repo-baseline itself** or i
 
 ## Discover and install Agent Skills
 
-Agent Skills are reusable, tool-portable capabilities defined by the [SKILL.md open standard](https://agentskills.io). Install skills that match **this** repository's technology stack and goals — skip anything irrelevant, since unused skills are noise.
+Install skills that match **this** repository's technology stack and goals — skip anything irrelevant, since unused skills are noise.
 
 ### Where to look (in priority order)
 
@@ -53,5 +51,5 @@ Treat a third-party skill as untrusted supply-chain content: its instructions en
 
 - **Skills are not verified or signed.** Inspect before installing — not just any `scripts/`, but the instruction body too, which can carry hidden or obfuscated prompt-injection directives (e.g. to exfiltrate secrets or run commands).
 - **Do not pre-approve `shell`/`bash`** in a skill's `allowed-tools` unless you have reviewed the skill and its scripts and trust the source — doing so lets a malicious or injected skill run arbitrary commands without confirmation.
-- **Prefer trusted, first-party sources** and the least privilege the task needs.
+- **Use the least privilege the task needs.**
 - **Installers are interchangeable.** The same skill can be installed with `gh skill install`, with `npx skills add <owner/repo>`, or by placing the skill folder directly in `.github/skills/` (or `.agents/skills/` for cross-tool use). Choose whichever matches the agent in use.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ This is a **baseline template repository** designed to provide a minimal, reusab
 
 ## Working Style
 
-**Simplicity.** Verbosity and complexity are harmful by default; deleting and simplifying almost always adds value. When asked to fix, fix in place — do NOT add new columns, rows, sections, rules, caveats, hedges, or "just in case" qualifications unless the user explicitly asked. Before producing output, ask: "what can I cut?"
+**Simplicity.** Verbosity and complexity are harmful by default; deleting and simplifying almost always adds value. When asked to fix, prefer fixing in place over adding. Before producing output, ask: "what can I cut?"
 
 ## Azure Access
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ This is a **baseline template repository** designed to provide a minimal, reusab
 
 ## Working Style
 
-**Simplicity.** Verbosity and complexity are harmful by default; deleting and simplifying almost always adds value. When asked to fix, prefer fixing in place over adding. Always ask: "what can I cut?"
+**Simplicity.** Verbosity and complexity are harmful by default; deleting and simplifying almost always adds value. When asked to fix, prefer fixing in place over adding. Make a habit of asking: "what can I cut?"
 
 ## Azure Access
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ This is a **baseline template repository** designed to provide a minimal, reusab
 
 ## Working Style
 
-**Simplicity.** Verbosity and complexity are harmful by default; deleting and simplifying almost always adds value. When asked to fix, prefer fixing in place over adding. Before producing output, ask: "what can I cut?"
+**Simplicity.** Verbosity and complexity are harmful by default; deleting and simplifying almost always adds value. When asked to fix, prefer fixing in place over adding. Before finalizing, ask: "what can I cut?"
 
 ## Azure Access
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,10 @@
 
 This is a **baseline template repository** designed to provide a minimal, reusable starting point for new GitHub repositories. It establishes foundational structure and conventions without making premature decisions about specific technologies, licenses, or deployment patterns.
 
+## Working Style
+
+**Simplicity.** Verbosity and complexity are harmful by default; deleting and simplifying almost always adds value. When asked to fix, fix in place — do NOT add new columns, rows, sections, rules, caveats, hedges, or "just in case" qualifications unless the user explicitly asked. Before producing output, ask: "what can I cut?"
+
 ## Azure Access
 
 The [Azure Developer CLI Copilot Coding Agent Extension](https://learn.microsoft.com/en-us/azure/developer/azure-developer-cli/extensions/copilot-coding-agent-extension) can give agents read-time visibility into Azure state while authoring changes. See [docs/azure-coding-agent-guide.md](docs/azure-coding-agent-guide.md) for guidance.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ This is a **baseline template repository** designed to provide a minimal, reusab
 
 ## Working Style
 
-**Simplicity.** Verbosity and complexity are harmful by default; deleting and simplifying almost always adds value. When asked to fix, prefer fixing in place over adding. Before finalizing, ask: "what can I cut?"
+**Simplicity.** Verbosity and complexity are harmful by default; deleting and simplifying almost always adds value. When asked to fix, prefer fixing in place over adding. Always ask: "what can I cut?"
 
 ## Azure Access
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This template is intentionally minimal and public-safe, containing no secrets, l
 
 ## Post-Creation Checklist
 
-After creating a repository from this template, the [`repo-setup` Agent Skill](.github/skills/repo-setup/SKILL.md) can walk an AI agent through these steps (including how to discover and install Agent Skills relevant to your stack):
+After creating a repository from this template, the [`repo-setup` Agent Skill](.github/skills/repo-setup/SKILL.md) can walk an AI agent through these steps:
 
 - [ ] **Choose and add a LICENSE file** - This template intentionally omits a license; add one appropriate for your project
 - [ ] **Configure Azure OIDC** (if using Azure) - Set up federated credentials and add the following repository secrets:

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This template is intentionally minimal and public-safe, containing no secrets, l
 
 ## Post-Creation Checklist
 
-After creating a repository from this template:
+After creating a repository from this template, the [`repo-setup` Agent Skill](.github/skills/repo-setup/SKILL.md) can walk an AI agent through these steps (including how to discover and install Agent Skills relevant to your stack):
 
 - [ ] **Choose and add a LICENSE file** - This template intentionally omits a license; add one appropriate for your project
 - [ ] **Configure Azure OIDC** (if using Azure) - Set up federated credentials and add the following repository secrets:
@@ -31,7 +31,7 @@ After creating a repository from this template:
   
   See [docs/azure-oidc-setup.md](docs/azure-oidc-setup.md) for detailed setup instructions. Then run the "Azure OIDC Connectivity Check" workflow manually to verify the configuration.
 - [ ] **Enable AI agent Azure access** (if using Azure with Copilot coding agent) - Run `azd coding-agent config` to give AI agents read-time visibility into Azure state while authoring changes. See [docs/azure-coding-agent-guide.md](docs/azure-coding-agent-guide.md) for guidance.
-- [ ] **Install Agent Skills** (optional) - Reusable [Agent Skills](https://agentskills.io) can be installed with [`gh skill install`](https://cli.github.com/manual/gh_skill_install) (GitHub CLI v2.90.0+), e.g. `gh skill install rukasakurai/agent-skills <skill>`.
+- [ ] **Discover and install Agent Skills** (optional) - Find reusable [Agent Skills](https://agentskills.io) relevant to your stack and install them with [`gh skill install`](https://cli.github.com/manual/gh_skill_install) (GitHub CLI v2.90.0+). See the [`repo-setup` skill](.github/skills/repo-setup/SKILL.md#discover-and-install-agent-skills) for where to look and how to vet them.
 - [ ] **Update README.md** - Replace this generic template README with repository-specific documentation
 - [ ] **Review AGENTS.md** - Update or remove this file to reflect your repository's specific purpose and conventions
 


### PR DESCRIPTION
Closes #20

Adds a `repo-setup` Agent Skill (`.github/skills/repo-setup/SKILL.md`) that guides an agent through post-creation setup of a repository derived from this template, and points the README Post-Creation Checklist at it.

Most relevant to #20, the skill adds **guidance on where to find Agent Skills** (vendor-first, then GitHub Copilot's default marketplaces, then `gh skill search`) and a **safety note that skills are unverified and must be inspected before installing**.

The skill also covers template-vs-derived context detection, optional Azure-scaffolding removal, and its own retirement once setup is complete.

Public-safe and neutral: no secrets/IDs, no hardcoded personal skills source, no assumed technology stack; the skill contains instructional text only (no executable scripts).